### PR TITLE
Date.today.xmlschema includes Time. 

### DIFF
--- a/lib/quickbooks/parser/qbxml_base.rb
+++ b/lib/quickbooks/parser/qbxml_base.rb
@@ -8,7 +8,7 @@ class Quickbooks::Parser::QbxmlBase
 
   FLOAT_CAST = Proc.new {|d| d ? Float(d) : 0.0}                                  
   BOOL_CAST  = Proc.new {|d| d ? (d == 'True' ? true : false) : false }          
-  DATE_CAST  = Proc.new {|d| d ? Date.parse(d).xmlschema : Date.today.xmlschema } 
+  DATE_CAST  = Proc.new {|d| d ? Date.parse(d).strftime("%Y-%m-%d") : Date.today.strftime("%Y-%m-%d") } 
   TIME_CAST  = Proc.new {|d| d ? Time.parse(d).xmlschema : Time.now.xmlschema }   
   INT_CAST   = Proc.new {|d| d ? Integer(d.to_i) : 0 }                                 
   STR_CAST   = Proc.new {|d| d ? String(d) : ''}                                  


### PR DESCRIPTION
On Ruby 1.9.2p290 

Date.today.xmlschema  => 2012-01-09T00:00:00Z

Quickbooks Expects only => 2012-01-09

This patches simply uses Strfttime to ensure the Date is formatted without the extra time information. 
