### PR TITLE
fix BOOLTYPE proc

### DIFF
--- a/lib/quickbooks/parser/qbxml_base.rb
+++ b/lib/quickbooks/parser/qbxml_base.rb
@@ -7,7 +7,7 @@ class Quickbooks::Parser::QbxmlBase
   QBXML_BASE = Quickbooks::Parser::QbxmlBase
 
   FLOAT_CAST = Proc.new {|d| d ? Float(d) : 0.0}                                  
-  BOOL_CAST  = Proc.new {|d| d ? (d == 'True' ? true : false) : false }          
+  BOOL_CAST  = Proc.new {|d| d ? (d == 'true' ? true : false) : false }          
   DATE_CAST  = Proc.new {|d| d ? Date.parse(d).strftime("%Y-%m-%d") : Date.today.strftime("%Y-%m-%d") } 
   TIME_CAST  = Proc.new {|d| d ? Time.parse(d).xmlschema : Time.now.xmlschema }   
   INT_CAST   = Proc.new {|d| d ? Integer(d.to_i) : 0 }                                 


### PR DESCRIPTION
We ran into an issue today where the gem was failing to properly parse boolean values in QBXML responses. Tracked it down to Line 10 of qbxml_base.rb having a capital 'T' for true, which should be lowercase according to the QBXML docs.
